### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete URL substring sanitization

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,14 @@ Rails.application.configure do
 
   # Rack Attack preferences
   rack_attack_url = Rails.application.credentials.dig(:REDIS, :REDIS_RACK_ATTACK_URL)
-  if rack_attack_url&.include?("upstash.io")
+  allowed_hosts = [ "upstash.io" ]
+  begin
+    rack_attack_parsed = rack_attack_url && URI.parse(rack_attack_url)
+    rack_attack_host = rack_attack_parsed&.host
+  rescue URI::InvalidURIError
+    rack_attack_host = nil
+  end
+  if rack_attack_host && allowed_hosts.include?(rack_attack_host)
     # Upstash requires SSL, convert to rediss:// and add SSL config
     rack_attack_url = rack_attack_url.sub(/^redis:\/\//, "rediss://")
     Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(


### PR DESCRIPTION
Potential fix for [https://github.com/seahal/umaxica-app-jit/security/code-scanning/17](https://github.com/seahal/umaxica-app-jit/security/code-scanning/17)

To address the problem, replace the substring check on line 98 with a check on the host component of the parsed URI. This ensures that only URLs where the host is exactly (or, if desired, a subdomain of) `upstash.io` are considered as Upstash URLs. The most robust and future-proof solution is to use Ruby's URI parser to parse `rack_attack_url`, extract its host part, and compare it against an explicit whitelist (e.g., `upstash.io`, `eu1.upstash.io`, etc., as appropriate for your application). 

Changes needed:
- Add an import for the `uri` module unless it's already available (Ruby's URI is global, so no import is needed).
- Change the conditional at line 98 to parse the URL, extract the host, and compare that (not by substring).
- Optionally, support subdomains only if necessary, by using a regular expression.
- Changes are contained entirely within the block starting at line 97.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
